### PR TITLE
Add cell/clipboard copy/paste tracking

### DIFF
--- a/src/PanelManager.ts
+++ b/src/PanelManager.ts
@@ -13,12 +13,15 @@ import { ExecutionDisposable } from './trackers/ExecutionDisposable';
 import { AlterationDisposable } from './trackers/AlterationDisposable';
 import { FocusDisposable } from './trackers/FocusDisposable';
 import { disabledNotebooksSignaler } from '.';
+import { JupyterFrontEnd } from '@jupyterlab/application';
 
 export class PanelManager {
   constructor(
+    app: JupyterFrontEnd,
     settings: ISettingRegistry.ISettings,
     dialogShownSettings: ISettingRegistry.ISettings
   ) {
+    this._app = app;
     this._panel = null;
 
     this._isDataCollectionEnabled = settings.get(EXTENSION_SETTING_NAME)
@@ -108,6 +111,7 @@ export class PanelManager {
             this._isDataCollectionEnabled
           ) {
             this._focusDisposable = new FocusDisposable(
+              this._app.commands,
               this._panel,
               notebookId
             );
@@ -209,6 +213,7 @@ export class PanelManager {
     this.panel = null;
   }
 
+  private _app: JupyterFrontEnd;
   private _panel: NotebookPanel | null;
   private _ongoingContextId = '';
   private _websocketManager: WebsocketManager;

--- a/src/api.ts
+++ b/src/api.ts
@@ -7,7 +7,10 @@ import {
   ICodeExecObject,
   INotebookClickObject,
   IMarkdownExecObject,
-  PostDataObject
+  PostDataObject,
+  ICellCopyObject,
+  ICellPasteObject,
+  IClipBoardObject
 } from './utils/types';
 
 const postRequest = (data: PostDataObject, endpoint: string): void => {
@@ -56,6 +59,22 @@ export const postMarkdownExec = (markdownExec: IMarkdownExecObject): void => {
 
 export const postCellClick = (cellClick: ICellClickObject): void => {
   postRequest(cellClick, 'clickevent/cell');
+};
+
+export const postCellCopy = (cellCopy: ICellCopyObject): void => {
+  postRequest(cellCopy, 'copyevent/cell');
+};
+
+export const postCellPaste = (cellPaste: ICellPasteObject): void => {
+  postRequest(cellPaste, 'pasteevent/cell');
+};
+
+export const postClipboardCopy = (clipboardCopy: IClipBoardObject): void => {
+  postRequest(clipboardCopy, 'copyevent/clipboard');
+};
+
+export const postClipboardPaste = (clipboardPaste: IClipBoardObject): void => {
+  postRequest(clipboardPaste, 'pasteevent/clipboard');
 };
 
 export const postNotebookClick = (

--- a/src/dataCollectionPlugin.ts
+++ b/src/dataCollectionPlugin.ts
@@ -43,7 +43,7 @@ export const dataCollectionPlugin = async (
     onEndpointChanged(endpointSettings);
     endpointSettings.changed.connect(onEndpointChanged);
 
-    const panelManager = new PanelManager(settings, dialogShownSettings);
+    const panelManager = new PanelManager(app, settings, dialogShownSettings);
 
     const labShell = app.shell as LabShell;
 

--- a/src/utils/types.d.ts
+++ b/src/utils/types.d.ts
@@ -44,9 +44,28 @@ export interface ICellAlterationObject extends IBaseEvent {
   time: string;
 }
 
+interface ICopyPaste extends IBaseEvent {
+  cell_id: string;
+  time: string;
+  content: string;
+}
+
+export interface ICellCopyObject extends ICopyPaste {}
+
+export interface ICellPasteObject extends ICopyPaste {
+  copied_notebook_id: string;
+  copied_cell_id: string;
+  copied_time: string;
+}
+
+export interface IClipBoardObject extends ICopyPaste {}
+
 export type PostDataObject =
   | ICodeExecObject
   | IMarkdownExecObject
   | INotebookClickObject
   | ICellClickObject
-  | ICellAlterationObject;
+  | ICellAlterationObject
+  | ICellCopyObject
+  | ICellPasteObject
+  | IClipBoardObject;


### PR DESCRIPTION
Copying and pasting a whole cell or from the clipboard is tracked and sent to the backend, along with the copied/pasted content.
See corresponding PR in the backend repository: https://github.com/chili-epfl/jupyter-analytics-backend/pull/1